### PR TITLE
Add logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Real-time plotting tool for triaxial tests.
    ```bash
    export SECRET_KEY=your-secret-key
    ```
-4. Run the application:
+4. (Optional) Set the `LOG_LEVEL` environment variable or pass `--log-level`
+   when running the application to adjust logging verbosity (e.g. `DEBUG`,
+   `INFO`).
+5. Run the application:
    ```bash
    python app.py
    ```


### PR DESCRIPTION
## Summary
- configure logging in `app.py`
- replace print calls with logging functions
- allow log level via `LOG_LEVEL` or `--log-level`
- document logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0853d8dc8330a227950caa28bfd8