### PR TITLE
Enable completion beep for static data loads

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,5 @@
 var socket = io();
+var beepAudio = document.getElementById('beep-sound');
 
 // Definición de trazos para los gráficos en tiempo real
 function createTrace(name) {
@@ -188,6 +189,10 @@ socket.on('static_data', function(static_data) {
         addStaticTraces(file_data);
     });
     plotStaticData();
+    if (beepAudio) {
+        beepAudio.currentTime = 0;
+        beepAudio.play();
+    }
 });
 
 function resetStaticTraces() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,6 +73,7 @@
             <p>CISMID: <span id="current-date"></span></p>
         </footer>
     </div>
+    <audio id="beep-sound" src="{{ url_for('static', filename='songs/beep-104060.mp3') }}" preload="auto"></audio>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     <script>
         function openNav() {


### PR DESCRIPTION
## Summary
- embed audio element for a beep sound
- initialize `beepAudio` in the main JS
- play sound when the server finishes loading static files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a09a07dbc83309b78d1369d779836