### PR TITLE
Allow debug mode via CLI or env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Real-time plotting tool for triaxial tests.
 4. (Optional) Set the `LOG_LEVEL` environment variable or pass `--log-level`
    when running the application to adjust logging verbosity (e.g. `DEBUG`,
    `INFO`).
-5. Run the application:
+5. (Optional) Control debug mode using the `DEBUG` environment variable or the
+   `--debug`/`--no-debug` command-line flags when starting the application.
+6. Run the application:
    ```bash
    python app.py
    ```

--- a/app.py
+++ b/app.py
@@ -244,8 +244,24 @@ if __name__ == '__main__':
         default=os.environ.get('LOG_LEVEL', 'INFO'),
         help='Set logging level (default: %(default)s)'
     )
+    # Determine debug mode from environment variable or CLI
+    env_debug = os.environ.get('DEBUG', 'False').lower() in ('1', 'true', 'yes')
+    parser.add_argument(
+        '--debug',
+        dest='debug',
+        action='store_true',
+        help='Enable debug mode'
+    )
+    parser.add_argument(
+        '--no-debug',
+        dest='debug',
+        action='store_false',
+        help='Disable debug mode'
+    )
+    parser.set_defaults(debug=env_debug)
+
     args = parser.parse_args()
     logging.getLogger().setLevel(
         getattr(logging, args.log_level.upper(), logging.INFO)
     )
-    socketio.run(app, debug=True)
+    socketio.run(app, debug=args.debug)


### PR DESCRIPTION
## Summary
- make debug mode configurable from `DEBUG` env var or `--debug`/`--no-debug` flags
- document how to enable/disable debug mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0a46e86c8330b8ec8804a26b4775