### PR TITLE
Stop beep on inactivity

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -185,6 +185,11 @@ socket.on('new_data', function(data) {
     redrawGraphs();
 });
 
+socket.on('stop_beep', function() {
+    stopBeepLoop();
+    monitoringStarted = false;
+});
+
 function updateMonitoringPanel(data) {
     document.getElementById('displacement').innerText = data.displacement.toFixed(3);
     document.getElementById('force').innerText = data.force.toFixed(2);


### PR DESCRIPTION
## Summary
- detect inactivity in monitor_file and emit `stop_beep`
- stop the beep loop on client when inactivity event is received

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae10d9efc8330bc885f5e018f8734