### PR TITLE
Add configurable sensor-column mapping and header inference for live and static files

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,13 @@ selected_file_path = None
 monitor_thread = None
 stop_event = None
 
+DEFAULT_SENSOR_MAPPING = {
+    'force_col': 'DEV 7 INPUT 1',
+    'displacement_col': 'DEV 7 INPUT 2',
+    'volume_col': 'DEV 4 INPUT 1',
+    'pressure_col': 'DEV 4 INPUT 2',
+}
+
 
 def sanitize_filename(name):
     """Return a safe file name within the data directory or None if invalid."""
@@ -29,6 +36,39 @@ def sanitize_filename(name):
     if os.path.isabs(name) or '..' in name or '/' in name or '\\' in name:
         return None
     return os.path.basename(name)
+
+
+def normalize_header_name(value):
+    return value.strip().strip('"').upper()
+
+
+def parse_header_map(header_line):
+    raw_headers = [item.strip() for item in header_line.strip().split(',') if item.strip()]
+    return {normalize_header_name(name): idx for idx, name in enumerate(raw_headers)}
+
+
+def get_selected_columns(params):
+    mapping = DEFAULT_SENSOR_MAPPING.copy()
+    if isinstance(params, dict):
+        for key in mapping:
+            user_value = params.get(key)
+            if isinstance(user_value, str) and user_value.strip():
+                mapping[key] = user_value.strip()
+    return mapping
+
+
+def extract_measurements(values, header_map, selected_columns):
+    force_idx = header_map[normalize_header_name(selected_columns['force_col'])]
+    displacement_idx = header_map[normalize_header_name(selected_columns['displacement_col'])]
+    volume_idx = header_map[normalize_header_name(selected_columns['volume_col'])]
+    pressure_idx = header_map[normalize_header_name(selected_columns['pressure_col'])]
+
+    return (
+        float(values[displacement_idx]),
+        float(values[force_idx]),
+        float(values[volume_idx]),
+        float(values[pressure_idx]),
+    )
 
 @app.route('/')
 def index():
@@ -81,7 +121,15 @@ def handle_selected_file(json):
     # Crear un nuevo evento y lanzar el hilo de monitoreo
     stop_event = threading.Event()
     monitor_thread = socketio.start_background_task(
-        monitor_file, stop_event, sigma3=sigma3, H0=H0, D0=D0, DH0=DH0, DV0=DV0, PP0=PP0
+        monitor_file,
+        stop_event,
+        sigma3=sigma3,
+        H0=H0,
+        D0=D0,
+        DH0=DH0,
+        DV0=DV0,
+        PP0=PP0,
+        selected_columns=get_selected_columns(json),
     )
 
 @socketio.on('load_static_files')
@@ -107,7 +155,16 @@ def handle_static_files(json):
             continue
         file_path = os.path.join('data', safe_name)
         params = static_params[i]
-        data = read_static_file(file_path, params['sigma3'], params['H0'], params['D0'], params['DH0'], params['DV0'], params['PP0'])
+        data = read_static_file(
+            file_path,
+            params['sigma3'],
+            params['H0'],
+            params['D0'],
+            params['DH0'],
+            params['DV0'],
+            params['PP0'],
+            get_selected_columns(params),
+        )
         static_data.append({'file_path': safe_name, 'data': data})
     # Envía los datos estáticos al cliente
     socketio.emit('static_data', static_data)
@@ -155,7 +212,7 @@ def calculate_effective_pq(sigma3, H0, D0, DH0, DV0, PP0, displacement, force, v
         'qp': qp
     }
 
-def read_static_file(file_path, sigma3, H0, D0, DH0, DV0, PP0):
+def read_static_file(file_path, sigma3, H0, D0, DH0, DV0, PP0, selected_columns=None):
     """Lee un archivo de datos y calcula trayectorias de esfuerzos efectivos.
 
     Parameters
@@ -171,15 +228,22 @@ def read_static_file(file_path, sigma3, H0, D0, DH0, DV0, PP0):
         Lista de diccionarios con los valores calculados para cada fila.
     """
     data = []
+    selected_columns = selected_columns or DEFAULT_SENSOR_MAPPING
     with open(file_path, 'r') as f:
         lines = f.readlines()
+        if not lines:
+            return data
+        header_map = parse_header_map(lines[0])
+        required_headers = [normalize_header_name(name) for name in selected_columns.values()]
+        if not all(header in header_map for header in required_headers):
+            logging.error('No se encontraron todas las columnas solicitadas en %s', file_path)
+            return data
         for line in lines[1:]:  # Omitir la primera línea si es un encabezado
             values = line.split(',')
             try:
-                displacement = float(values[4])
-                force = float(values[3])
-                volume = float(values[5])
-                pressure = float(values[6])
+                displacement, force, volume, pressure = extract_measurements(
+                    values, header_map, selected_columns
+                )
 
                 # Utilizar función para calcular trayectorias de esfuerzos efectivos
                 calculated_data = calculate_effective_pq(sigma3, H0, D0, DH0, DV0, PP0, displacement, force, volume, pressure)
@@ -188,7 +252,7 @@ def read_static_file(file_path, sigma3, H0, D0, DH0, DV0, PP0):
                 logging.error('Error de conversión en la línea: %s - %s', line, e)
     return data
 
-def monitor_file(stop_event, sigma3, H0, D0, DH0, DV0, PP0):
+def monitor_file(stop_event, sigma3, H0, D0, DH0, DV0, PP0, selected_columns=None):
     """Monitorea en tiempo real el archivo seleccionado y emite nuevos datos.
 
     Parameters
@@ -212,6 +276,8 @@ def monitor_file(stop_event, sigma3, H0, D0, DH0, DV0, PP0):
     last_update = time.time()
     beep_stopped = False
     timeout = 5  # segundos sin actualizaciones antes de detener el sonido
+    selected_columns = selected_columns or DEFAULT_SENSOR_MAPPING
+    header_map = None
     while not stop_event.is_set():
         new_size = os.path.getsize(selected_file_path)
         if new_size > current_size:
@@ -219,14 +285,16 @@ def monitor_file(stop_event, sigma3, H0, D0, DH0, DV0, PP0):
                 f.seek(current_size)
                 lines = f.readlines()
                 for line in lines:
+                    if header_map is None and 'INDEX' in line.upper() and 'TIME' in line.upper():
+                        header_map = parse_header_map(line)
+                        continue
                     values = line.split(',')
-                    if len(values) < 7 or not values[0].strip().isdigit():  # Ignorar líneas incorrectas o encabezados
+                    if len(values) < 2 or not values[0].strip().isdigit() or header_map is None:
                         continue
                     try:
-                        displacement = float(values[4])
-                        force = float(values[3])
-                        volume = float(values[5])
-                        pressure = float(values[6])
+                        displacement, force, volume, pressure = extract_measurements(
+                            values, header_map, selected_columns
+                        )
 
                         # Utiliza la función para calcular las trayectorias de esfuerzos efectivos
                         data = calculate_effective_pq(sigma3, H0, D0, DH0, DV0, PP0, displacement, force, volume, pressure)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,6 +3,72 @@ var beepAudio = document.getElementById('beep-sound');
 var monitoringStarted = false;
 var beepLooping = false;
 
+var DEFAULT_SENSOR_MAPPING = {
+    force_col: 'DEV 7 INPUT 1',
+    displacement_col: 'DEV 7 INPUT 2',
+    volume_col: 'DEV 4 INPUT 1',
+    pressure_col: 'DEV 4 INPUT 2'
+};
+
+function normalizeHeader(value) {
+    return value.trim().replace(/^"|"$/g, '').toUpperCase();
+}
+
+function inferColumnsFromHeaderLine(headerLine) {
+    var inferred = Object.assign({}, DEFAULT_SENSOR_MAPPING);
+    if (!headerLine) {
+        return inferred;
+    }
+
+    var headers = headerLine
+        .split(',')
+        .map(function(item) { return item.trim(); })
+        .filter(function(item) { return item.length > 0; });
+
+    var inputColumns = headers.filter(function(header) {
+        return /^DEV\s+\d+\s+INPUT\s+[12]$/i.test(normalizeHeader(header));
+    });
+
+    var pairs = [];
+    for (var i = 0; i + 1 < inputColumns.length; i++) {
+        var first = normalizeHeader(inputColumns[i]);
+        var second = normalizeHeader(inputColumns[i + 1]);
+        if (first.endsWith('INPUT 1') && second.endsWith('INPUT 2')) {
+            pairs.push({ input1: inputColumns[i], input2: inputColumns[i + 1] });
+            i += 1;
+        }
+    }
+
+    if (pairs.length >= 2) {
+        inferred.volume_col = pairs[0].input1;
+        inferred.pressure_col = pairs[0].input2;
+        inferred.force_col = pairs[1].input1;
+        inferred.displacement_col = pairs[1].input2;
+    }
+
+    return inferred;
+}
+
+function applyMappingToForm(mapping, suffix) {
+    ['force_col', 'displacement_col', 'volume_col', 'pressure_col'].forEach(function(key) {
+        var element = document.getElementById(key + suffix);
+        if (element && mapping[key]) {
+            element.value = mapping[key];
+        }
+    });
+}
+
+function readHeaderAndFillDefaults(file, suffix) {
+    var reader = new FileReader();
+    reader.onload = function(e) {
+        var content = String(e.target.result || '');
+        var firstLine = content.split(/\r?\n/)[0] || '';
+        var mapping = inferColumnsFromHeaderLine(firstLine);
+        applyMappingToForm(mapping, suffix);
+    };
+    reader.readAsText(file.slice(0, 4096));
+}
+
 function startBeepLoop() {
     if (!beepAudio || beepLooping) {
         return;
@@ -96,6 +162,8 @@ document.getElementById('file-input').addEventListener('change', function(event)
     if (file) {
         console.log(`Archivo seleccionado: ${file.name}`);
         document.getElementById('file-params').style.display = 'block';
+        applyMappingToForm(DEFAULT_SENSOR_MAPPING, '');
+        readHeaderAndFillDefaults(file, '');
         document.getElementById('submit-params').onclick = function() {
             var params = {
                 name: file.name,
@@ -104,7 +172,11 @@ document.getElementById('file-input').addEventListener('change', function(event)
                 D0: parseFloat(document.getElementById('D0').value),
                 DH0: parseFloat(document.getElementById('DH0').value),
                 DV0: parseFloat(document.getElementById('DV0').value),
-                PP0: parseFloat(document.getElementById('PP0').value)
+                PP0: parseFloat(document.getElementById('PP0').value),
+                force_col: document.getElementById('force_col').value,
+                displacement_col: document.getElementById('displacement_col').value,
+                volume_col: document.getElementById('volume_col').value,
+                pressure_col: document.getElementById('pressure_col').value
             };
             stopBeepLoop();
             monitoringStarted = false;
@@ -157,7 +229,19 @@ function createStaticFileParamsForm(file, index) {
         <input type="number" id="DV0_${index}" name="DV0_${index}" step="0.01" value="0"><br>
         <label for="PP0_${index}">PP0:</label>
         <input type="number" id="PP0_${index}" name="PP0_${index}" step="0.01" value="0"><br>
+        <label for="force_col_${index}">Fuerza:</label>
+        <input type="text" id="force_col_${index}" name="force_col_${index}" value="DEV 7 INPUT 1"><br>
+        <label for="displacement_col_${index}">Desplazamiento:</label>
+        <input type="text" id="displacement_col_${index}" name="displacement_col_${index}" value="DEV 7 INPUT 2"><br>
+        <label for="volume_col_${index}">Volumen:</label>
+        <input type="text" id="volume_col_${index}" name="volume_col_${index}" value="DEV 4 INPUT 1"><br>
+        <label for="pressure_col_${index}">Presión:</label>
+        <input type="text" id="pressure_col_${index}" name="pressure_col_${index}" value="DEV 4 INPUT 2"><br>
     `;
+    setTimeout(function() {
+        applyMappingToForm(DEFAULT_SENSOR_MAPPING, `_${index}`);
+        readHeaderAndFillDefaults(file, `_${index}`);
+    }, 0);
     return div;
 }
 
@@ -170,7 +254,11 @@ function getStaticFileParams(index) {
         D0: parseFloat(document.getElementById(`D0_${index}`).value),
         DH0: parseFloat(document.getElementById(`DH0_${index}`).value),
         DV0: parseFloat(document.getElementById(`DV0_${index}`).value),
-        PP0: parseFloat(document.getElementById(`PP0_${index}`).value)
+        PP0: parseFloat(document.getElementById(`PP0_${index}`).value),
+        force_col: document.getElementById(`force_col_${index}`).value,
+        displacement_col: document.getElementById(`displacement_col_${index}`).value,
+        volume_col: document.getElementById(`volume_col_${index}`).value,
+        pressure_col: document.getElementById(`pressure_col_${index}`).value
     };
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,12 +30,22 @@
             <input type="number" id="DV0" name="DV0" step="0.01" value="0"><br>
             <label for="PP0">PP0:</label>
             <input type="number" id="PP0" name="PP0" step="0.01" value="0"><br>
+            <h4>Columnas de sensores</h4>
+            <label for="force_col">Fuerza:</label>
+            <input type="text" id="force_col" name="force_col" value="DEV 7 INPUT 1"><br>
+            <label for="displacement_col">Desplazamiento:</label>
+            <input type="text" id="displacement_col" name="displacement_col" value="DEV 7 INPUT 2"><br>
+            <label for="volume_col">Volumen:</label>
+            <input type="text" id="volume_col" name="volume_col" value="DEV 4 INPUT 1"><br>
+            <label for="pressure_col">Presión:</label>
+            <input type="text" id="pressure_col" name="pressure_col" value="DEV 4 INPUT 2"><br>
             <button id="submit-params">Enviar</button>
         </div>
         <button id="select-static-files-button">Seleccionar Archivos Estáticos</button>
         <input type="file" id="static-file-input" style="display: none;" multiple>
         <div id="static-file-params" style="display: none;">
             <h3>Ingrese los parámetros para los archivos estáticos seleccionados</h3>
+            <p>Usa los mismos nombres de columnas del archivo TXT para cada variable.</p>
             <div id="static-file-params-container"></div>
             <button id="submit-static-params">Enviar Parámetros Estáticos</button>
         </div>


### PR DESCRIPTION
### Motivation
- Allow processing files with different sensor column names by making sensor-to-column mapping configurable and inferable from file headers.
- Make parsing robust against varying CSV/TXT headers and avoid hard-coded column indexes in `read_static_file` and `monitor_file`.
- Provide a UI to override or auto-fill column mappings when selecting live or static data files.

### Description
- Introduce `DEFAULT_SENSOR_MAPPING`, `normalize_header_name`, `parse_header_map`, `get_selected_columns`, and `extract_measurements` and use them to map sensor names to CSV columns in `app.py` and replace hard-coded column indexes.  
- Update `read_static_file` to accept `selected_columns` and to parse the header line via `parse_header_map` before extracting and converting values.  
- Update `monitor_file` to detect and parse the header line on-the-fly and to use `extract_measurements` for real-time rows, and pass `selected_columns` from the socket handler.  
- Frontend changes in `static/js/main.js` add `DEFAULT_SENSOR_MAPPING`, header inference (`inferColumnsFromHeaderLine`), automatic form population (`applyMappingToForm` and `readHeaderAndFillDefaults`), and new form fields to submit column mappings for both live and static file uploads, plus corresponding updates to `templates/index.html` to show the new inputs.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cea19929483309c83c4dcb6096380)